### PR TITLE
build: exclude flaky tests in Playwright e2e workflow

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -50,7 +50,7 @@ on:
         playwright-test-args:
             description: "Playwright test command CLI arguments"
             type: string
-            default: "--project=Portal --workers=8"
+            default: "--project=Portal --workers=8 --grep-invert=@flaky"
         apihub-backend-image-tag:
             description: "BE image tag to be executed"
             type: string


### PR DESCRIPTION
This change aims to improve the reliability of the CI pipeline by preventing intermittent test failures from affecting the overall test results.