### PR TITLE
build: add timeout for step calling npm ci

### DIFF
--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -2,6 +2,12 @@ name: frontend-ci
 
 on:
   workflow_call:
+    inputs:
+      install_dependencies_timeout:
+        description: "Timeout for the 'Install dependencies' step in minutes"
+        required: false
+        default: 10
+        type: number
     outputs:
       npm_dist_tag:
         description: "NPM dist-tag of the published package."
@@ -29,6 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        timeout-minutes: ${{ inputs.install_dependencies_timeout }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -1,7 +1,13 @@
 name: Run screenshot tests
 
 on:
-  workflow_call
+  workflow_call:
+    inputs:
+      install_dependencies_timeout:
+        description: "Timeout for the 'Install dependencies' step in minutes"
+        required: false
+        default: 10
+        type: number
 
 jobs:
   screenshot-tests:
@@ -20,6 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        timeout-minutes: ${{ inputs.install_dependencies_timeout }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/storybook-cd.yaml
+++ b/.github/workflows/storybook-cd.yaml
@@ -1,7 +1,13 @@
 name: Deploy Storybook
 
 on:
-  workflow_call
+  workflow_call:
+    inputs:
+      install_dependencies_timeout:
+        description: "Timeout for the 'Install dependencies' step in minutes"
+        required: false
+        default: 10
+        type: number
 
 jobs:
   deploy-storybook:
@@ -23,6 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        timeout-minutes: ${{ inputs.install_dependencies_timeout }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/vscode-extension-ci.yaml
+++ b/.github/workflows/vscode-extension-ci.yaml
@@ -2,6 +2,12 @@ name: build VSCode extension
 
 on:
   workflow_call:
+    inputs:
+      install_dependencies_timeout:
+        description: "Timeout for the 'Install dependencies' step in minutes"
+        required: false
+        default: 10
+        type: number
     outputs:
       npm_dist_tag:
         description: "NPM dist-tag of the published package."
@@ -32,6 +38,7 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        timeout-minutes: ${{ inputs.install_dependencies_timeout }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       


### PR DESCRIPTION
`npm ci` step hangs up intermittently in our workflows. There's a number of GitHub issue for similar problems (see https://github.com/actions/setup-node/issues/1297 for example).

This change is to limit damage when this happens (by default timeout is 6 hours, this reduces timeout for 'Install dependencies' step to 10 minutes by default, configurable from calling workflow if necessary). By statistics under normal circumstances 'Install dependencies' step takes no more than 6 minutes worst case (in apispec-view and api-doc-viewer components)