### PR TITLE
fix(screenshot-tests): add additional check for test failure outcomes

### DIFF
--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -82,5 +82,5 @@ jobs:
           retention-days: 14
 
       - name: Check test results
-        if: steps.check_diffs.outputs.has_diffs == 'true'
+        if: steps.check_diffs.outputs.has_diffs == 'true' || steps.tests.outcome == 'failure'
         run: exit 1


### PR DESCRIPTION
Fixes a case when something was wrong with the 'Run test' step itself (e.g. no corresponding npm script to run screenshot tests)