### PR TITLE
chore: update Node.js to v.24

### DIFF
--- a/.github/workflows/automatic-pr-labeler.yaml
+++ b/.github/workflows/automatic-pr-labeler.yaml
@@ -24,7 +24,7 @@ jobs:
     if: (github.event.pull_request.merged == false) && (github.event.pull_request.user.login != 'dependabot[bot]') && (github.event.pull_request.user.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: "Execute assign labels"
         id: action-assign-labels

--- a/.github/workflows/automatic-pr-labeler.yaml
+++ b/.github/workflows/automatic-pr-labeler.yaml
@@ -10,9 +10,9 @@ name: Automatic PR Labeler
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [ develop, main ]
     types:
-      [opened, reopened, synchronize]
+      [ opened, reopened, synchronize ]
 
 permissions:
   pull-requests: write
@@ -24,7 +24,7 @@ jobs:
     if: (github.event.pull_request.merged == false) && (github.event.pull_request.user.login != 'dependabot[bot]') && (github.event.pull_request.user.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: "Execute assign labels"
         id: action-assign-labels

--- a/.github/workflows/delete-dist-tag.yaml
+++ b/.github/workflows/delete-dist-tag.yaml
@@ -1,7 +1,7 @@
 name: delete-dist-tag
 
 on:
-  workflow_call:    
+  workflow_call:
 
 jobs:
   delete-dist-tag:
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -19,13 +19,13 @@ jobs:
 
       - name: Calculate NPM dist tag
         id: calculate_npm_dist_tag
-        run: |          
+        run: |
           REF=${{ github.event.ref }}
           echo "REF: $REF"
           NPM_DIST_TAG=$(echo $REF | sed 's@^refs/tags/.*@latest@;s@^refs/heads/@@;s@^refs/pull/@pull/@;s@^develop$@dev@;s@^release$@next@;s@^main$@@;s@/@-@g;')
           echo "NPM_DIST_TAG: $NPM_DIST_TAG"
           echo "npm_dist_tag=$NPM_DIST_TAG" >> $GITHUB_OUTPUT
-      
+
       - name: Delete associated NPM dist tags
         if: |
           steps.calculate_npm_dist_tag.outputs.npm_dist_tag != '' && 
@@ -51,5 +51,5 @@ jobs:
               npm dist-tag rm "$PACKAGE_NAME" "$TAG_NAME"
             fi
           done
-        env:        
+        env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-dist-tag.yaml
+++ b/.github/workflows/delete-dist-tag.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/delete-dist-tag.yaml
+++ b/.github/workflows/delete-dist-tag.yaml
@@ -12,9 +12,9 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Calculate NPM dist tag

--- a/.github/workflows/delete-dist-tag.yaml
+++ b/.github/workflows/delete-dist-tag.yaml
@@ -1,7 +1,7 @@
 name: delete-dist-tag
 
 on:
-  workflow_call:
+  workflow_call: {}
 
 jobs:
   delete-dist-tag:
@@ -28,8 +28,8 @@ jobs:
 
       - name: Delete associated NPM dist tags
         if: |
-          steps.calculate_npm_dist_tag.outputs.npm_dist_tag != '' && 
-          steps.calculate_npm_dist_tag.outputs.npm_dist_tag != 'latest' &&           
+          steps.calculate_npm_dist_tag.outputs.npm_dist_tag != '' &&
+          steps.calculate_npm_dist_tag.outputs.npm_dist_tag != 'latest' &&
           steps.calculate_npm_dist_tag.outputs.npm_dist_tag != 'dev'
         run: |
           # Get package names to process

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -65,7 +65,7 @@ jobs:
           echo "GIT_HASH=$shortSha" >> $GITHUB_OUTPUT
           echo "GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           no-cache: true
           context: ${{ inputs.context }}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -38,13 +38,13 @@ jobs:
       image_tag: ${{ steps.prepare_tag.outputs.TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${GITHUB_ACTOR}
@@ -63,7 +63,7 @@ jobs:
           echo "GIT_HASH=$shortSha" >> $GITHUB_OUTPUT
           echo "GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           no-cache: true
           context: ${{ inputs.context }}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -21,6 +21,8 @@ on:
     secrets:
       NPMRC:
         required: false
+      GH_ACCESS_TOKEN:
+        required: false
     outputs:
       image_tag:
         description: "Docker image tag of the published image."

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -52,6 +52,9 @@ jobs:
         run: npm ls --json |  jq -r '.dependencies | keys[]' | grep "@netcracker" | xargs --no-run-if-empty npm update
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # npm update triggers postinstall scripts — same flags as Install step above.
+          PUPPETEER_SKIP_DOWNLOAD: 1
+          HUSKY: 0
 
       # This step is to update internal dependencies specified via dist tag version to their latest available versions
       - name: Update dependencies

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Install dependencies

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -11,7 +11,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -11,7 +11,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/pr-assigner.yml
+++ b/.github/workflows/pr-assigner.yml
@@ -25,7 +25,7 @@ jobs:
           fi
 
       - name: "Checkout Repository"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -16,6 +16,6 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: webiny/action-conventional-commits@v1.3.0

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -16,6 +16,6 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: webiny/action-conventional-commits@v1.3.0

--- a/.github/workflows/pr-lint-title.yaml
+++ b/.github/workflows/pr-lint-title.yaml
@@ -18,6 +18,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -3,7 +3,7 @@ name: Generate Pull Requests Report
 on:
   schedule:
     - cron: '0 9 * * *'
-  workflow_dispatch:      
+  workflow_dispatch: { }
 
 jobs:
   generate-report:
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -32,7 +32,7 @@ jobs:
           cp public/report_prs_*.html public/report_prs_latest.html
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: prs-report
           path: report_prs_*.html

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -38,7 +38,7 @@ jobs:
           path: report_prs_*.html
 
       - name: Upload to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -32,7 +32,7 @@ jobs:
           cp public/report_prs_*.html public/report_prs_latest.html
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: prs-report
           path: report_prs_*.html

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -32,7 +32,7 @@ jobs:
           cp public/report_prs_*.html public/report_prs_latest.html
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: prs-report
           path: report_prs_*.html

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -3,7 +3,7 @@ name: Generate Pull Requests Report
 on:
   schedule:
     - cron: '0 9 * * *'
-  workflow_dispatch: { }
+  workflow_dispatch: {}
 
 jobs:
   generate-report:

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -38,7 +38,7 @@ jobs:
           path: report_prs_*.html
 
       - name: Upload to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4.1
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/release-report.yml
+++ b/.github/workflows/release-report.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -31,7 +31,7 @@ jobs:
         run: python .github/workflows/scripts/github-issues-release-report.py
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: release-report
           path: report_*.html

--- a/.github/workflows/release-report.yml
+++ b/.github/workflows/release-report.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -31,7 +31,7 @@ jobs:
         run: python .github/workflows/scripts/github-issues-release-report.py
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-report
           path: report_*.html

--- a/.github/workflows/release-report.yml
+++ b/.github/workflows/release-report.yml
@@ -31,7 +31,7 @@ jobs:
         run: python .github/workflows/scripts/github-issues-release-report.py
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: release-report
           path: report_*.html

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -3,81 +3,81 @@ name: run E2E tests
 on:
   workflow_call:
     inputs:
-        compose-repository-url:
-            description: "URL of the repository to clone"
-            type: string
-            default: "https://github.com/Netcracker/qubership-apihub"
-        compose-repository-branch:
-            description: "Branch to clone"
-            type: string
-            default: "main"
-        compose-repository-compose-folder:
-            description: "Path to the folder with docker-compose file"
-            type: string
-            default: "docker-compose/apihub-generic"
-        compose-repository-compose-file:
-            description: "docker-compose filename"
-            type: string
-            default: "docker-compose.yml"
-        postman-collections-run:
-            description: "Flag for executing postman collections"
-            type: boolean
-            default: true
-        postman-repository-url:
-            description: "URL of the repository to clone"
-            type: string
-            default: "https://github.com/Netcracker/qubership-apihub-postman-collections"
-        postman-repository-branch:
-            description: "Branch to clone"
-            type: string
-        postman-collections-list:
-            description: "Collections to execute"
-            type: string
-            default: "./e2e/1_1_Smoke_Portal.postman_collection.json"
-        playwright-tests-run:
-            description: "Flag for executing playwright tests"
-            type: boolean
-            default: true
-        playwright-repository-url:
-            description: "URL of the repository to clone"
-            type: string
-            default: "https://github.com/Netcracker/qubership-apihub-ui-tests"
-        playwright-repository-branch:
-            description: "Branch to clone"
-            type: string
-        playwright-test-args:
-            description: "Playwright test command CLI arguments"
-            type: string
-            default: "--project=Portal --workers=8 --grep-invert=@flaky"
-        apihub-backend-image-tag:
-            description: "BE image tag to be executed"
-            type: string
-            default: "dev"
-        apihub-build-task-consumer-image-tag:
-            description: "Build Task Consumer image tag to be executed"
-            type: string
-            default: "dev"
-        apihub-ui-image-tag:
-            description: "UI image tag to be executed"
-            type: string
-            default: "dev"
-        apihub-api-linter-service-image-tag:
-            description: "API Linter Service image tag to be executed"
-            type: string
-            default: "dev"
-        apihub-agents-backend-image-tag:
-            description: "Agents Backend image tag to be executed"
-            type: string
-            default: "dev"
+      compose-repository-url:
+        description: "URL of the repository to clone"
+        type: string
+        default: "https://github.com/Netcracker/qubership-apihub"
+      compose-repository-branch:
+        description: "Branch to clone"
+        type: string
+        default: "main"
+      compose-repository-compose-folder:
+        description: "Path to the folder with docker-compose file"
+        type: string
+        default: "docker-compose/apihub-generic"
+      compose-repository-compose-file:
+        description: "docker-compose filename"
+        type: string
+        default: "docker-compose.yml"
+      postman-collections-run:
+        description: "Flag for executing postman collections"
+        type: boolean
+        default: true
+      postman-repository-url:
+        description: "URL of the repository to clone"
+        type: string
+        default: "https://github.com/Netcracker/qubership-apihub-postman-collections"
+      postman-repository-branch:
+        description: "Branch to clone"
+        type: string
+      postman-collections-list:
+        description: "Collections to execute"
+        type: string
+        default: "./e2e/1_1_Smoke_Portal.postman_collection.json"
+      playwright-tests-run:
+        description: "Flag for executing playwright tests"
+        type: boolean
+        default: true
+      playwright-repository-url:
+        description: "URL of the repository to clone"
+        type: string
+        default: "https://github.com/Netcracker/qubership-apihub-ui-tests"
+      playwright-repository-branch:
+        description: "Branch to clone"
+        type: string
+      playwright-test-args:
+        description: "Playwright test command CLI arguments"
+        type: string
+        default: "--project=Portal --workers=8 --grep-invert=@flaky"
+      apihub-backend-image-tag:
+        description: "BE image tag to be executed"
+        type: string
+        default: "dev"
+      apihub-build-task-consumer-image-tag:
+        description: "Build Task Consumer image tag to be executed"
+        type: string
+        default: "dev"
+      apihub-ui-image-tag:
+        description: "UI image tag to be executed"
+        type: string
+        default: "dev"
+      apihub-api-linter-service-image-tag:
+        description: "API Linter Service image tag to be executed"
+        type: string
+        default: "dev"
+      apihub-agents-backend-image-tag:
+        description: "Agents Backend image tag to be executed"
+        type: string
+        default: "dev"
     secrets:
-        JWT_PRIVATE_KEY:
-            required: true
-        APIHUB_ADMIN_EMAIL:
-            required: true
-        APIHUB_ADMIN_PASSWORD:
-            required: true
-        APIHUB_ACCESS_TOKEN:
-            required: true
+      JWT_PRIVATE_KEY:
+        required: true
+      APIHUB_ADMIN_EMAIL:
+        required: true
+      APIHUB_ADMIN_PASSWORD:
+        required: true
+      APIHUB_ACCESS_TOKEN:
+        required: true
 
 jobs:
   run_compose_and_run_tests:
@@ -86,7 +86,7 @@ jobs:
       - name: Clone compose repository
         run: |
           git clone --branch ${{ inputs.compose-repository-branch }} --single-branch ${{ inputs.compose-repository-url }} compose-repo
-      
+
       - name: Install Podman and envsubst
         run: |
           sudo apt-get update
@@ -107,12 +107,12 @@ jobs:
         run: |
           cd compose-repo
           set
-          for env_file in $(find . -name "*.env"); do
+          find . -name "*.env" -print0 | while IFS= read -r -d '' env_file; do
             envsubst < "$env_file" > "${env_file}.tmp"
             mv "${env_file}.tmp" "$env_file"
           done
 
-          cd ${{ inputs.compose-repository-compose-folder }}    
+          cd ${{ inputs.compose-repository-compose-folder }}
           envsubst < qubership-apihub-backend-config.yaml > qubership-apihub-backend-config.yaml.tmp
           mv qubership-apihub-backend-config.yaml.tmp qubership-apihub-backend-config.yaml
 
@@ -147,7 +147,7 @@ jobs:
       - name: Wait for APIHUB startup
         run: |
           echo "Waiting for http://localhost:8081/login to return 200..."
-          end_time=$((SECONDS + 60))  
+          end_time=$((SECONDS + 60))
           while [ $SECONDS -lt $end_time ]; do
             status_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/login)
             if [ "$status_code" -eq 200 ]; then
@@ -174,7 +174,7 @@ jobs:
         run: |
           # First check if a branch was provided as input
           BRANCH="${{ inputs.postman-repository-branch }}"
-          
+
           # If a branch was provided, check if it exists
           if [ -n "$BRANCH" ]; then
             if git ls-remote --heads ${{ inputs.postman-repository-url }} refs/heads/$BRANCH | grep -q $BRANCH; then
@@ -188,7 +188,7 @@ jobs:
             BRANCH="develop"
             echo "No branch specified, using develop as default"
           fi
-          
+
           echo "Using postman tests repository branch: $BRANCH"
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
@@ -238,9 +238,9 @@ jobs:
             FAILED_TESTS=$(grep -A1 '<h6 class="text-uppercase">Total Failed Tests</h6>' "$file" | grep -oP '(?<=<h1 class="display-1">)[0-9]+(?=</h1>)')
             TOTAL_FAILED=$((TOTAL_FAILED + FAILED_TESTS))
           done
-    
-          if [ "$TOTAL_FAILED" -ne 0 ]; then            
-            exit 1          
+
+          if [ "$TOTAL_FAILED" -ne 0 ]; then
+            exit 1
           fi
 
       - name: Calculate Playwright tests branch
@@ -249,7 +249,7 @@ jobs:
         run: |
           # First check if a branch was provided as input
           BRANCH="${{ inputs.playwright-repository-branch }}"
-          
+
           # If a branch was provided, check if it exists
           if [ -n "$BRANCH" ]; then
             if git ls-remote --heads ${{ inputs.playwright-repository-url }} refs/heads/$BRANCH | grep -q $BRANCH; then
@@ -263,7 +263,7 @@ jobs:
             BRANCH="develop"
             echo "No branch specified, using develop as default"
           fi
-          
+
           echo "Using playwright tests repository branch: $BRANCH"
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
@@ -275,7 +275,7 @@ jobs:
       - name: Install Playwright
         if: ${{ inputs.playwright-tests-run }}
         working-directory: ./playwright-repo
-        run: |          
+        run: |
           npm ci
           npx playwright install --with-deps chromium
         env:
@@ -291,8 +291,8 @@ jobs:
           TEST_USER_PASSWORD: ${{ secrets.APIHUB_ADMIN_PASSWORD }}
           PLAYGROUND_BACKEND_HOST: "http://host.docker.internal:8081"
           CLEAR_TD: "skip"
-        run: |          
-          npx playwright test ${{ inputs.playwright-test-args }}          
+        run: |
+          npx playwright test ${{ inputs.playwright-test-args }}
 
       - name: Upload Playwright reports as artifacts
         if: ${{ inputs.playwright-tests-run }}
@@ -320,10 +320,10 @@ jobs:
             echo "|------------------------------------------|------------------------------------------------------------------------------------------|"
             echo "| **Execute BE tests**                     | **\`${{ inputs.postman-collections-run }}\`**                                            |"
             echo "| Postman collections branch to clone      | \`${{ steps.calculate-postman-branch.outputs.branch || 'branch was not calculated' }}\`  |"
-            
+
             # Build collections list - split comma-separated string into separate lines
             # to avoid breaking table formatting with very long single line
-          
+
             echo -n "| Postman collections to execute | "
             IFS=',' read -ra COLLECTIONS <<< "${{ inputs.postman-collections-list }}"
             for i in "${!COLLECTIONS[@]}"; do
@@ -333,7 +333,7 @@ jobs:
               echo -n "\`${COLLECTIONS[$i]}\`"
             done
             echo " |"
-            
+
             echo "| **Execute UI tests**                  | **\`${{ inputs.playwright-tests-run }}\`**                                                 |"
             echo "| Playwright branch to clone            | \`${{ steps.calculate-playwright-branch.outputs.branch || 'branch was not calculated' }}\` |"
             echo "| Playwright test command CLI arguments | \`${{ inputs.playwright-test-args }}\`                                                     |"

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Upload Newman reports as artifacts
         if: ${{ inputs.postman-collections-run }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: newman-reports
           path: |
@@ -296,7 +296,7 @@ jobs:
 
       - name: Upload Playwright reports as artifacts
         if: ${{ inputs.playwright-tests-run }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-reports
           path: |
@@ -304,7 +304,7 @@ jobs:
             retention-days: 7
 
       - name: Upload containers logs as artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: containers-logs
           path: |

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Upload Newman reports as artifacts
         if: ${{ inputs.postman-collections-run }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: newman-reports
           path: |
@@ -296,7 +296,7 @@ jobs:
 
       - name: Upload Playwright reports as artifacts
         if: ${{ inputs.playwright-tests-run }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-reports
           path: |
@@ -304,7 +304,7 @@ jobs:
             retention-days: 7
 
       - name: Upload containers logs as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: containers-logs
           path: |

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -93,9 +93,9 @@ jobs:
           sudo apt-get install -y podman podman-compose gettext-base
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Template .env and config.yaml files with environment variables

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Upload Newman reports as artifacts
         if: ${{ inputs.postman-collections-run }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: newman-reports
           path: |
@@ -296,7 +296,7 @@ jobs:
 
       - name: Upload Playwright reports as artifacts
         if: ${{ inputs.playwright-tests-run }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-reports
           path: |
@@ -304,7 +304,7 @@ jobs:
             retention-days: 7
 
       - name: Upload containers logs as artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: containers-logs
           path: |

--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -41,6 +41,9 @@ jobs:
         run: npm ls --json |  jq -r '.dependencies | keys[]' | grep "@netcracker" | xargs --no-run-if-empty npm update
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # npm update triggers postinstall scripts — same flags as Install step above.
+          PUPPETEER_SKIP_DOWNLOAD: 1
+          HUSKY: 0
 
       # This step is to update internal dependencies specified via dist tag version to their latest available versions
       - name: Update dependencies

--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload artifacts
         if: steps.check_diffs.outputs.has_diffs == 'true' || inputs.update_screenshots == true
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.update_screenshots == true && 'updated-screenshots' || 'screenshot-differences' }}
           path: artifact-staging

--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          npm_script="${{ inputs.update_screenshots == true && 'regenerate-screenshots:docker' || 'screenshot-test:docker' }}"
+          npm_script="${{ inputs.update_screenshots == true && 'regenerate-screenshots' || 'screenshot-test' }}"
           echo "Running npm script: ${npm_script}"
           npm run "${npm_script}"
           exit_code="$?"

--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
       # Configure npm registry URL since we're using GitHub packages. Node.js environment is pre-installed in the qubership-apihub-nodejs-dev-image:1.7.3 container.
       - name: Setup npm registry
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           registry-url: "https://npm.pkg.github.com/"
 

--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -12,7 +12,7 @@ on:
         description: "Container image to use for the job (optional)"
         required: false
         type: string
-        default: ghcr.io/netcracker/qubership-apihub-nodejs-dev-image:1.8.0
+        default: ghcr.io/netcracker/qubership-apihub-nodejs-dev-image:feature-nodejs24
       update_screenshots:
         description: "Regenerate screenshots"
         required: false

--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -8,11 +8,6 @@ on:
         required: false
         default: 10
         type: number
-      container:
-        description: "Container image to use for the job (optional)"
-        required: false
-        type: string
-        default: ghcr.io/netcracker/qubership-apihub-nodejs-dev-image:feature-nodejs24
       update_screenshots:
         description: "Regenerate screenshots"
         required: false
@@ -22,15 +17,14 @@ jobs:
   screenshot-tests:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    container: ${{ inputs.container }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      # Configure npm registry URL since we're using GitHub packages. Node.js environment is pre-installed in the qubership-apihub-nodejs-dev-image:1.7.3 container.
-      - name: Setup npm registry
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
+          node-version: "24"
           registry-url: "https://npm.pkg.github.com/"
 
       - name: Install dependencies
@@ -38,6 +32,9 @@ jobs:
         timeout-minutes: ${{ inputs.install_dependencies_timeout }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Avoid slow/hanging installs on CI: skip Puppeteer downloads and disable Husky hook setup.
+          PUPPETEER_SKIP_DOWNLOAD: 1
+          HUSKY: 0
 
       # remove once all components have update-lock-file npm script
       - name: Update dependencies (deprecated)
@@ -63,7 +60,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          npm_script="${{ inputs.update_screenshots == true && 'regenerate-screenshots:ci' || 'screenshot-test:ci' }}"
+          npm_script="${{ inputs.update_screenshots == true && 'regenerate-screenshots:docker' || 'screenshot-test:docker' }}"
           echo "Running npm script: ${npm_script}"
           npm run "${npm_script}"
           exit_code="$?"
@@ -79,7 +76,7 @@ jobs:
           echo "List __image_snapshots__ directory:"
           find . -name "__image_snapshots__" -type d -exec ls -la {} +
 
-      # Manual diff check (previously a workaround since 'npm run screenshot-test:ci' always exited with code 0 even on errors in apispec-view; now kept as a safety measure)
+      # Manual diff check (previously a workaround since 'npm run screenshot-test:docker' always exited with code 0 even on errors in apispec-view; now kept as a safety measure)
       - name: Check for diff files
         id: check_diffs
         if: inputs.update_screenshots == false

--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload artifacts
         if: steps.check_diffs.outputs.has_diffs == 'true' || inputs.update_screenshots == true
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.update_screenshots == true && 'updated-screenshots' || 'screenshot-differences' }}
           path: artifact-staging

--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload artifacts
         if: steps.check_diffs.outputs.has_diffs == 'true' || inputs.update_screenshots == true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ inputs.update_screenshots == true && 'updated-screenshots' || 'screenshot-differences' }}
           path: artifact-staging

--- a/.github/workflows/sprint-report-v2.yml
+++ b/.github/workflows/sprint-report-v2.yml
@@ -28,7 +28,7 @@ jobs:
         run: python .github/workflows/scripts/github-issues-sprint-report-v2.py
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: sprint-report
           path: report_*.html

--- a/.github/workflows/sprint-report-v2.yml
+++ b/.github/workflows/sprint-report-v2.yml
@@ -3,7 +3,7 @@ name: Generate Current Sprint Report v2
 on:
   schedule:
     - cron: '0 15 * * *'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   generate-report:

--- a/.github/workflows/sprint-report-v2.yml
+++ b/.github/workflows/sprint-report-v2.yml
@@ -3,7 +3,7 @@ name: Generate Current Sprint Report v2
 on:
   schedule:
     - cron: '0 15 * * *'
-  workflow_dispatch:      
+  workflow_dispatch:
 
 jobs:
   generate-report:
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -28,7 +28,7 @@ jobs:
         run: python .github/workflows/scripts/github-issues-sprint-report-v2.py
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sprint-report
           path: report_*.html

--- a/.github/workflows/sprint-report-v2.yml
+++ b/.github/workflows/sprint-report-v2.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -28,7 +28,7 @@ jobs:
         run: python .github/workflows/scripts/github-issues-sprint-report-v2.py
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: sprint-report
           path: report_*.html

--- a/.github/workflows/sprint-report.yml
+++ b/.github/workflows/sprint-report.yml
@@ -3,7 +3,7 @@ name: Generate Current Sprint Report
 on:
   schedule:
     - cron: '0 15 * * *'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   generate-report:

--- a/.github/workflows/sprint-report.yml
+++ b/.github/workflows/sprint-report.yml
@@ -3,7 +3,7 @@ name: Generate Current Sprint Report
 on:
   schedule:
     - cron: '0 15 * * *'
-  workflow_dispatch:      
+  workflow_dispatch:
 
 jobs:
   generate-report:
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -28,7 +28,7 @@ jobs:
         run: python .github/workflows/scripts/github-issues-sprint-report.py
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sprint-report
           path: report_*.html

--- a/.github/workflows/sprint-report.yml
+++ b/.github/workflows/sprint-report.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -28,7 +28,7 @@ jobs:
         run: python .github/workflows/scripts/github-issues-sprint-report.py
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: sprint-report
           path: report_*.html

--- a/.github/workflows/sprint-report.yml
+++ b/.github/workflows/sprint-report.yml
@@ -28,7 +28,7 @@ jobs:
         run: python .github/workflows/scripts/github-issues-sprint-report.py
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: sprint-report
           path: report_*.html

--- a/.github/workflows/storybook-cd.yaml
+++ b/.github/workflows/storybook-cd.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Install dependencies

--- a/.github/workflows/storybook-cd.yaml
+++ b/.github/workflows/storybook-cd.yaml
@@ -56,7 +56,7 @@ jobs:
         run: npm run build:showcase
 
       - name: Deploy Storybook to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1
         with:
           destination_dir: ${{ github.ref_name }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook-cd.yaml
+++ b/.github/workflows/storybook-cd.yaml
@@ -56,7 +56,7 @@ jobs:
         run: npm run build:showcase
 
       - name: Deploy Storybook to gh-pages
-        uses: peaceiris/actions-gh-pages@v4.1
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           destination_dir: ${{ github.ref_name }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -40,7 +40,7 @@ jobs:
           sparse-checkout: |
             config/linters
       - name: "Upload the common linters configsuration"
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: linter-config
           path: "${{ github.workspace }}/config"
@@ -60,7 +60,7 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
       - name: "Get the common linters configuration"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         id: download
         with:
           name: linter-config

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Get the common linters configuration"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: main # fix/superlinter-config
           repository: netcracker/.github
           sparse-checkout: |
             config/linters
       - name: "Upload the common linters configsuration"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: linter-config
           path: "${{ github.workspace }}/config"
@@ -55,12 +55,12 @@ jobs:
       statuses: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
       - name: "Get the common linters configuration"
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         id: download
         with:
           name: linter-config

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -32,19 +32,19 @@ jobs:
   prepare-configs:
     runs-on: ubuntu-latest
     steps:
-    - name: "Get the common linters configuration"
-      uses: actions/checkout@v5
-      with:
-        ref: main # fix/superlinter-config
-        repository: netcracker/.github
-        sparse-checkout: |
-          config/linters
-    - name: "Upload the common linters configsuration"
-      uses: actions/upload-artifact@v5
-      with:
-        name: linter-config
-        path: "${{ github.workspace }}/config"
-        include-hidden-files: true
+      - name: "Get the common linters configuration"
+        uses: actions/checkout@v5
+        with:
+          ref: main # fix/superlinter-config
+          repository: netcracker/.github
+          sparse-checkout: |
+            config/linters
+      - name: "Upload the common linters configsuration"
+        uses: actions/upload-artifact@v5
+        with:
+          name: linter-config
+          path: "${{ github.workspace }}/config"
+          include-hidden-files: true
   run-lint:
     needs: [prepare-configs]
     runs-on: ubuntu-latest
@@ -54,41 +54,41 @@ jobs:
       # To report GitHub Actions status checks
       statuses: write
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v5
-      with:
-        # Full git history is needed to get a proper list of changed files within `super-linter`
-        fetch-depth: 0
-    - name: "Get the common linters configuration"
-      uses: actions/download-artifact@v5
-      id: download
-      with:
-        name: linter-config
-        path: /tmp/linter-config
-    - name: "Apply the common linters configuration"
-      if: ${{ steps.download.outputs.download-path != '' }}
-      run: |
-        mkdir -p ./.github/linters
-        cp --update=none -vR /tmp/linter-config/linters/* ./.github/linters
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+      - name: "Get the common linters configuration"
+        uses: actions/download-artifact@v5
+        id: download
+        with:
+          name: linter-config
+          path: /tmp/linter-config
+      - name: "Apply the common linters configuration"
+        if: ${{ steps.download.outputs.download-path != '' }}
+        run: |
+          mkdir -p ./.github/linters
+          cp --update=none -vR /tmp/linter-config/linters/* ./.github/linters
 
-    - name: "Load super-linter environment file"
-      shell: bash
-      run: |
-        # shellcheck disable=2086
-        if [ -f "${GITHUB_WORKSPACE}/.github/super-linter.env" ]; then
-          echo "Applying local linter environment:"
-          grep "\S" ${GITHUB_WORKSPACE}/.github/super-linter.env | grep -v "^#"
-          grep "\S" ${GITHUB_WORKSPACE}/.github/super-linter.env | grep -v "^#" >> $GITHUB_ENV
-        elif [ -f "/tmp/linter-config/linters/super-linter.env" ]; then
-          echo "::warning:: Local linter environment file .github/super-linter.env is not found"
-          echo "Applying common linter environment:"
-          grep "\S" /tmp/linter-config/linters/super-linter.env | grep -v "^#"
-          grep "\S" /tmp/linter-config/linters/super-linter.env | grep -v "^#" >> $GITHUB_ENV
-        fi
+      - name: "Load super-linter environment file"
+        shell: bash
+        run: |
+          # shellcheck disable=2086
+          if [ -f "${GITHUB_WORKSPACE}/.github/super-linter.env" ]; then
+            echo "Applying local linter environment:"
+            grep "\S" ${GITHUB_WORKSPACE}/.github/super-linter.env | grep -v "^#"
+            grep "\S" ${GITHUB_WORKSPACE}/.github/super-linter.env | grep -v "^#" >> $GITHUB_ENV
+          elif [ -f "/tmp/linter-config/linters/super-linter.env" ]; then
+            echo "::warning:: Local linter environment file .github/super-linter.env is not found"
+            echo "Applying common linter environment:"
+            grep "\S" /tmp/linter-config/linters/super-linter.env | grep -v "^#"
+            grep "\S" /tmp/linter-config/linters/super-linter.env | grep -v "^#" >> $GITHUB_ENV
+          fi
 
-    - name: Lint Code Base
-      uses: super-linter/super-linter/slim@v7.3.0
-      env:
-        VALIDATE_ALL_CODEBASE: ${{ inputs.full_scan || false }}
-        # To report GitHub Actions status checks
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint Code Base
+        uses: super-linter/super-linter/slim@v7.3.0
+        env:
+          VALIDATE_ALL_CODEBASE: ${{ inputs.full_scan || false }}
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Get the common linters configuration"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: main # fix/superlinter-config
         repository: netcracker/.github
         sparse-checkout: |
           config/linters
     - name: "Upload the common linters configsuration"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: linter-config
         path: "${{ github.workspace }}/config"
@@ -55,12 +55,12 @@ jobs:
       statuses: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         # Full git history is needed to get a proper list of changed files within `super-linter`
         fetch-depth: 0
     - name: "Get the common linters configuration"
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       id: download
       with:
         name: linter-config

--- a/.github/workflows/vscode-extension-ci.yaml
+++ b/.github/workflows/vscode-extension-ci.yaml
@@ -139,7 +139,7 @@ jobs:
           echo "Found VSIX: $VSIX_PATH"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: runner.os == 'Linux'
         with:
           name: extension

--- a/.github/workflows/vscode-extension-ci.yaml
+++ b/.github/workflows/vscode-extension-ci.yaml
@@ -11,17 +11,17 @@ on:
     outputs:
       npm_dist_tag:
         description: "NPM dist-tag of the published package."
-        value: ${{ jobs.on-push.outputs.npm_dist_tag }}
+        value: ${{ jobs.build.outputs.npm_dist_tag }}
       package_version:
         description: "NPM version of the published package."
-        value: ${{ jobs.on-push.outputs.package_version }}      
+        value: ${{ jobs.build.outputs.package_version }}
 
 jobs:
   build:
     if: github.event_name == 'push'
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     outputs:
       npm_dist_tag: ${{ steps.calculate_npm_dist_tag.outputs.npm_dist_tag }}
@@ -58,7 +58,7 @@ jobs:
       - name: Calculate NPM dist tag
         id: calculate_npm_dist_tag
         shell: bash
-        run: |          
+        run: |
           REF=${{ github.ref }}
           echo "REF: $REF"
           NPM_DIST_TAG=$(echo $REF | sed 's@^refs/tags/.*@latest@;s@^refs/heads/@@;s@^refs/pull/@pull/@;s@^develop$@dev@;s@^release$@next@;s@^main$@@;s@/@-@g;')
@@ -66,9 +66,9 @@ jobs:
           echo "npm_dist_tag=$NPM_DIST_TAG" >> $GITHUB_OUTPUT
 
       - name: Calculate prerelease suffix
-        id: calculate_prerelease_suffix        
+        id: calculate_prerelease_suffix
         shell: bash
-        run: |          
+        run: |
           NPM_DIST_TAG="${{ steps.calculate_npm_dist_tag.outputs.npm_dist_tag }}"
           if [ -n "$NPM_DIST_TAG" ] && [ "$NPM_DIST_TAG" != "latest" ]; then
             PRERELEASE_SUFFIX="$NPM_DIST_TAG"
@@ -78,10 +78,10 @@ jobs:
           echo "PRERELEASE_SUFFIX: $PRERELEASE_SUFFIX"
           echo "prerelease_suffix=$PRERELEASE_SUFFIX" >> $GITHUB_OUTPUT        
 
-      - name: Bump version (dev branches only)        
+      - name: Bump version (dev branches only)
         if: steps.calculate_prerelease_suffix.outputs.prerelease_suffix != ''
         shell: bash
-        run: |          
+        run: |
           # Get the current version and extract release part
           CURRENT_VERSION=$(jq -r '.version' package.json)          
           
@@ -105,7 +105,7 @@ jobs:
         run: |
           VERSION=$(jq -r '.version' package.json)          
           echo "package_version=$VERSION" >> $GITHUB_OUTPUT
-      
+
       - name: Build the package
         shell: bash
         run: |
@@ -115,7 +115,7 @@ jobs:
             CURRENT_BRANCH="main"          
           fi
           npx vsce package --githubBranch $CURRENT_BRANCH
-        
+
       # This step is necessary to receive access to the test resources 
       # Based on https://github.com/redhat-developer/vscode-extension-tester-example/blob/ac13a9d622127d04c667a138984cd9814b04d502/.github/workflows/main.yml#L39
       - name: Allow unprivileged user namespace (ubuntu)
@@ -132,9 +132,9 @@ jobs:
 
       - name: Get VSIX filename
         id: get_vsix
-        shell: bash 
+        shell: bash
         run: |
-          VSIX_PATH=$(ls *.vsix)
+          VSIX_PATH=$(ls ./*.vsix)
           echo "vsix_path=$VSIX_PATH" >> $GITHUB_OUTPUT
           echo "Found VSIX: $VSIX_PATH"
 

--- a/.github/workflows/vscode-extension-ci.yaml
+++ b/.github/workflows/vscode-extension-ci.yaml
@@ -139,7 +139,7 @@ jobs:
           echo "Found VSIX: $VSIX_PATH"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: runner.os == 'Linux'
         with:
           name: extension

--- a/.github/workflows/vscode-extension-ci.yaml
+++ b/.github/workflows/vscode-extension-ci.yaml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Install dependencies

--- a/.github/workflows/vscode-extension-ci.yaml
+++ b/.github/workflows/vscode-extension-ci.yaml
@@ -41,7 +41,7 @@ jobs:
         timeout-minutes: ${{ inputs.install_dependencies_timeout }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       # remove once all components have update-lock-file npm script
       - name: Update dependencies (deprecated)
         shell: bash
@@ -76,34 +76,34 @@ jobs:
             PRERELEASE_SUFFIX=''
           fi
           echo "PRERELEASE_SUFFIX: $PRERELEASE_SUFFIX"
-          echo "prerelease_suffix=$PRERELEASE_SUFFIX" >> $GITHUB_OUTPUT        
+          echo "prerelease_suffix=$PRERELEASE_SUFFIX" >> $GITHUB_OUTPUT
 
       - name: Bump version (dev branches only)
         if: steps.calculate_prerelease_suffix.outputs.prerelease_suffix != ''
         shell: bash
         run: |
           # Get the current version and extract release part
-          CURRENT_VERSION=$(jq -r '.version' package.json)          
-          
+          CURRENT_VERSION=$(jq -r '.version' package.json)
+
           # Extract release part (remove any prerelease suffix if exists)
           RELEASE_VERSION=$(echo "$CURRENT_VERSION" | sed -E 's/(-[^+]+)?(\+[^+]+)?$//')
-          
+
           # Generate timestamp in YYYYMMDDHHmmss format
           TIMESTAMP=$(date -u '+%Y%m%d%H%M%S')
-          
+
           # Construct new version
           NEW_VERSION="${RELEASE_VERSION}-${{ steps.calculate_prerelease_suffix.outputs.prerelease_suffix }}.${TIMESTAMP}"
-          
+
           echo "NEW_VERSION: $NEW_VERSION"
-          
+
           # Set the new version
-          npm version "${NEW_VERSION}" --no-git-tag-version          
+          npm version "${NEW_VERSION}" --no-git-tag-version
 
       - name: Get package version
         id: get_version
         shell: bash
         run: |
-          VERSION=$(jq -r '.version' package.json)          
+          VERSION=$(jq -r '.version' package.json)
           echo "package_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build the package
@@ -112,11 +112,11 @@ jobs:
           CURRENT_BRANCH=$(echo ${{ github.event.ref }} | sed 's/refs\/heads\///')
           echo "CURRENT_BRANCH: $CURRENT_BRANCH"
           if [[ "$CURRENT_BRANCH" == refs/tags/* ]]; then
-            CURRENT_BRANCH="main"          
+            CURRENT_BRANCH="main"
           fi
           npx vsce package --githubBranch $CURRENT_BRANCH
 
-      # This step is necessary to receive access to the test resources 
+      # This step is necessary to receive access to the test resources
       # Based on https://github.com/redhat-developer/vscode-extension-tester-example/blob/ac13a9d622127d04c667a138984cd9814b04d502/.github/workflows/main.yml#L39
       - name: Allow unprivileged user namespace (ubuntu)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/vscode-extension-ci.yaml
+++ b/.github/workflows/vscode-extension-ci.yaml
@@ -28,7 +28,7 @@ jobs:
       package_version: ${{ steps.get_version.outputs.package_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/vscode-extension-ci.yaml
+++ b/.github/workflows/vscode-extension-ci.yaml
@@ -139,7 +139,7 @@ jobs:
           echo "Found VSIX: $VSIX_PATH"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: runner.os == 'Linux'
         with:
           name: extension


### PR DESCRIPTION
## Migrate CI workflows to Node.js 24                                                                                                                                                                                                                                                                             
   
  ### Summary                                                                                                                                                                                                                                                                                                       
                                                            
  - Upgrade Node.js runtime from **20** to **24** across all CI workflows
  - Bump all GitHub Actions to their latest Node 24-compatible versions
  - Rearchitect screenshot tests: remove `container` input (previously running inside `qubership-apihub-nodejs-dev-image`) and switch to bare `ubuntu-latest` runner — Chrome is now managed by `jest-chrome-in-docker-environment` in docker mode
  - Switch screenshot test npm scripts from `screenshot-test:ci` / `regenerate-screenshots:ci` to `screenshot-test:docker` / `regenerate-screenshots:docker`
  - Add `PUPPETEER_SKIP_DOWNLOAD=1` and `HUSKY=0` to all `npm ci` / `npm update` steps in `screenshot-tests.yaml` and `frontend-ci.yaml` to prevent unnecessary Chromium downloads and git hook setup in CI
  - Fix pre-existing linter errors (ShellCheck, yamllint, GitHub Actions linter)

  ### GitHub Actions version bumps

  | Action | Before | After |
  |--------|--------|-------|
  | `actions/checkout` | `@v3`, `@v4` | `@v6` |
  | `actions/setup-node` | `@v4` | `@v6` |
  | `actions/upload-artifact` | `@v4` | `@v7` |
  | `actions/download-artifact` | `@v4` | `@v8` |
  | `actions/setup-python` | `@v4` | `@v6` |
  | `docker/build-push-action` | `@v5` | `@v7` |
  | `docker/setup-qemu-action` | `@v3` | `@v4` |
  | `docker/setup-buildx-action` | `@v3` | `@v4` |
  | `docker/login-action` | `@v3` | `@v4` |
  | `peaceiris/actions-gh-pages` | `@v4` | `@v4.1.0` |
  | `amannn/action-semantic-pull-request` | `@v5` | `@v6` |

  ### Changed workflows

  | Workflow | Changes |
  |---|---|
  | `screenshot-tests.yaml` | Removed `container` input, added `actions/setup-node@v6` with `node-version: 24`, switched to `:docker` npm scripts, added `PUPPETEER_SKIP_DOWNLOAD` / `HUSKY` env vars |
  | `frontend-ci.yaml` | `node-version: 20` → `24`, added `PUPPETEER_SKIP_DOWNLOAD` / `HUSKY` to install/update steps |
  | `docker-ci.yml` | All actions bumped (see table above), added `GH_ACCESS_TOKEN` to secrets section |
  | `run-e2e-tests.yml` | `actions/setup-node@v4` → `@v6`, `node-version: 20` → `24`, fixed ShellCheck SC2044 (`for..$(find)` → `find -print0 \| while read`) |
  | `delete-dist-tag.yaml` | `actions/checkout@v4` → `@v6`, `actions/setup-node@v4` → `@v6`, `node-version: 20` → `24`, fixed `workflow_call:` empty value |
  | `vscode-extension-ci.yaml` | `actions/checkout@v4` → `@v6`, `actions/setup-node@v4` → `@v6`, `node-version: 20` → `24`, fixed job reference (`jobs.on-push` → `jobs.build`), fixed ShellCheck SC2035 (`ls *.vsix` → `ls ./*.vsix`) |
  | `storybook-cd.yaml` | `node-version: 20` → `24`, `peaceiris/actions-gh-pages@v4` → `@v4.1.0` |
  | `super-linter.yaml` | All actions bumped, fixed YAML indentation (4 → 6 for steps) |
  | `pr-lint-title.yaml` | `amannn/action-semantic-pull-request@v5` → `@v6` |
  | `pr-report.yml` | `actions/checkout@v3` → `@v6`, `actions/setup-python@v4` → `@v6`, `actions/upload-artifact@v4` → `@v7`, fixed `workflow_dispatch:` empty value |
  | `sprint-report.yml` | `actions/checkout@v3` → `@v6`, `actions/setup-python@v4` → `@v6`, `actions/upload-artifact@v4` → `@v7`, fixed `workflow_dispatch:` empty value |
  | `sprint-report-v2.yml` | Same as sprint-report.yml |
  | `release-report.yml` | `actions/checkout@v3` → `@v6`, `actions/setup-python@v4` → `@v6` |

  ### Linter fixes

  | Issue | Fix | File(s) |
  |-------|-----|---------|
  | ShellCheck SC2044 | `for..$(find)` → `find -print0 \| while read` | `run-e2e-tests.yml` |
  | ShellCheck SC2035 | `ls *.vsix` → `ls ./*.vsix` | `vscode-extension-ci.yaml` |
  | yamllint empty-values | `workflow_dispatch:` → `workflow_dispatch: {}` | `delete-dist-tag.yaml`, `pr-report.yml`, `sprint-report.yml`, `sprint-report-v2.yml` |
  | yamllint indentation | Fixed step indentation from 4 to 6 | `super-linter.yaml` |
  | GitHub Actions linter | Fixed job reference `jobs.on-push` → `jobs.build` | `vscode-extension-ci.yaml` |
  | Undeclared secret | Added `GH_ACCESS_TOKEN` to secrets | `docker-ci.yml` |
  | Trailing spaces | Stripped from all modified files | All workflows |

  ### Why bump GitHub Actions versions?

  Actions like `actions/checkout@v4` use Node 20 as their internal runtime. GitHub will force-switch all actions to Node 24 on June 2, 2026 and remove Node 20 from runners on September 16, 2026. The updated versions use Node 24 natively, eliminating deprecation warnings.

  ### Why remove the container from screenshot-tests?

  Previously, screenshot tests ran inside the `qubership-apihub-nodejs-dev-image` container which had Node.js and Chrome pre-installed. With the migration to `jest-chrome-in-docker-environment`, Chrome is launched in its own Docker container automatically. The dev-image container is no longer needed —
  Node.js is installed via `actions/setup-node`, and Chrome is managed by the test environment.

  ### Why `PUPPETEER_SKIP_DOWNLOAD=1` and `HUSKY=0`?

  - **`PUPPETEER_SKIP_DOWNLOAD=1`**: Puppeteer's postinstall script downloads Chromium (~200 MB). In docker mode, Chrome runs inside a container managed by `jest-chrome-in-docker-environment`, so the downloaded binary is never used. Skipping it avoids slow or hanging installs.
  - **`HUSKY=0`**: Husky's `prepare` script installs git hooks, which are unnecessary in CI and can interfere with the build.

  Both flags are set on every step that runs `npm ci` or `npm update`, since both trigger postinstall/prepare scripts.

