### PR TITLE
feat: add Kind-based E2E test workflow

### DIFF
--- a/.github/workflows/run-e2e-tests-kind.yaml
+++ b/.github/workflows/run-e2e-tests-kind.yaml
@@ -204,19 +204,25 @@ jobs:
         env:
           APIHUB_ACCESS_TOKEN: ${{ secrets.APIHUB_ACCESS_TOKEN }}
         run: |
-          echo "Waiting for APIHUB UI and API key authentication..."
+          echo "Waiting for APIHUB and end-to-end API key authentication..."
           end_time=$((SECONDS + 300))
           while [ $SECONDS -lt $end_time ]; do
             login_status=$(curl -s -o /dev/null -w "%{http_code}" \
               http://localhost:8081/login || true)
             api_key_status=$(curl -s -o /dev/null -w "%{http_code}" \
               --header "api-key: $APIHUB_ACCESS_TOKEN" \
-              http://localhost:8081/api/v1/system/info || true)
-            if [ "$login_status" = "200" ] && [ "$api_key_status" = "200" ]; then
-              echo "APIHUB UI is ready and the API key is accepted."
+              http://localhost:8081/api/v2/auth/apiKey || true)
+            agents_backend_status=$(curl -s -o /dev/null -w "%{http_code}" \
+              --header "api-key: $APIHUB_ACCESS_TOKEN" \
+              http://localhost:8081/agents-backend/api/v2/agents || true)
+            if [ "$login_status" = "200" ] \
+              && [ "$api_key_status" = "200" ] \
+              && [ "$agents_backend_status" = "200" ]; then
+              echo "APIHUB and Agents Backend accept the API key."
               exit 0
             fi
-            echo "Login status: $login_status; API key status: $api_key_status. Retrying in 5 seconds..."
+            echo "Login: $login_status; API key: $api_key_status; Agents Backend: $agents_backend_status."
+            echo "Retrying in 5 seconds..."
             sleep 5
           done
           echo "Timeout reached. APIHUB was not ready within 5 minutes."
@@ -240,6 +246,22 @@ jobs:
             qubershipApihubAgent.env.technicalParameters.apihub.accessToken="$RUNNER_TEMP/apihub-agent-access-token" \
             --wait \
             --timeout 5m
+
+      - name: Verify Qubership APIHUB Agent access token
+        if: ${{ inputs.apihub-agent-run }}
+        env:
+          APIHUB_ACCESS_TOKEN: ${{ secrets.APIHUB_ACCESS_TOKEN }}
+        run: |
+          if kubectl get secret qubership-apihub-agent-config-secret \
+            --namespace qubership-apihub-agent \
+            --output=jsonpath='{.data.config\.yaml}' \
+            | base64 --decode \
+            | grep --fixed-strings --quiet -- "$APIHUB_ACCESS_TOKEN"; then
+            echo "Agent configuration contains the expected APIHUB access token."
+          else
+            echo "::error::Agent configuration does not contain the expected APIHUB access token."
+            exit 1
+          fi
 
       - name: Install Newman
         if: ${{ inputs.postman-collections-run }}

--- a/.github/workflows/run-e2e-tests-kind.yaml
+++ b/.github/workflows/run-e2e-tests-kind.yaml
@@ -1,0 +1,394 @@
+name: run E2E tests in Kind
+
+on:
+  workflow_call:
+    inputs:
+      helm-repository-url:
+        description: "URL of the repository containing Helm templates"
+        type: string
+        default: "https://github.com/Netcracker/qubership-apihub"
+      helm-repository-branch:
+        description: "Branch containing Helm templates"
+        type: string
+        default: "main"
+      postman-collections-run:
+        description: "Flag for executing postman collections"
+        type: boolean
+        default: true
+      postman-repository-url:
+        description: "URL of the repository to clone"
+        type: string
+        default: "https://github.com/Netcracker/qubership-apihub-postman-collections"
+      postman-repository-branch:
+        description: "Branch to clone"
+        type: string
+      postman-collections-list:
+        description: "Collections to execute"
+        type: string
+        default: "./e2e/1_1_Smoke_Portal.postman_collection.json"
+      playwright-tests-run:
+        description: "Flag for executing playwright tests"
+        type: boolean
+        default: true
+      playwright-repository-url:
+        description: "URL of the repository to clone"
+        type: string
+        default: "https://github.com/Netcracker/qubership-apihub-ui-tests"
+      playwright-repository-branch:
+        description: "Branch to clone"
+        type: string
+      playwright-test-args:
+        description: "Playwright test command CLI arguments"
+        type: string
+        default: "--project=Portal --workers=8 --grep-invert=@flaky"
+      apihub-backend-image-tag:
+        description: "BE image tag to be executed"
+        type: string
+        default: "dev"
+      apihub-build-task-consumer-image-tag:
+        description: "Build Task Consumer image tag to be executed"
+        type: string
+        default: "dev"
+      apihub-ui-image-tag:
+        description: "UI image tag to be executed"
+        type: string
+        default: "dev"
+      apihub-api-linter-service-image-tag:
+        description: "API Linter Service image tag to be executed"
+        type: string
+        default: "dev"
+      apihub-agents-backend-image-tag:
+        description: "Agents Backend image tag to be executed"
+        type: string
+        default: "dev"
+    secrets:
+      JWT_PRIVATE_KEY:
+        required: true
+      APIHUB_ADMIN_EMAIL:
+        required: true
+      APIHUB_ADMIN_PASSWORD:
+        required: true
+      APIHUB_ACCESS_TOKEN:
+        required: true
+
+jobs:
+  run_kind_and_run_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone deployment repository
+        run: |
+          git clone --branch ${{ inputs.helm-repository-branch }} --single-branch \
+            ${{ inputs.helm-repository-url }} helm-repo
+
+      - name: Install envsubst
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext-base
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://npm.pkg.github.com/'
+
+      - name: Create Kind configuration
+        run: |
+          cat > kind-config.yaml <<'EOF'
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+            - role: control-plane
+              extraPortMappings:
+                - containerPort: 80
+                  hostPort: 80
+                  protocol: TCP
+                - containerPort: 443
+                  hostPort: 443
+                  protocol: TCP
+          EOF
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: apihub-e2e
+          config: kind-config.yaml
+          wait: 120s
+
+      - name: Install ingress controller
+        run: |
+          kubectl apply -f \
+            https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+          kubectl wait --namespace ingress-nginx \
+            --for=condition=Ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=180s
+
+      - name: Prepare APIHUB secrets
+        working-directory: helm-repo/helm-templates/local-k8s-quickstart
+        env:
+          JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
+          APIHUB_ADMIN_EMAIL: ${{ secrets.APIHUB_ADMIN_EMAIL }}
+          APIHUB_ADMIN_PASSWORD: ${{ secrets.APIHUB_ADMIN_PASSWORD }}
+          APIHUB_ACCESS_TOKEN: ${{ secrets.APIHUB_ACCESS_TOKEN }}
+        run: |
+          envsubst < qubership-apihub/local-secrets.yaml.template \
+            > qubership-apihub/local-secrets.yaml
+
+      - name: Deploy PostgreSQL
+        working-directory: helm-repo/helm-templates/local-k8s-quickstart
+        run: |
+          helm upgrade --install postgres-db ./postgres-db \
+            --namespace postgres-db \
+            --create-namespace \
+            --wait \
+            --timeout 5m
+
+      - name: Deploy APIHUB
+        working-directory: helm-repo/helm-templates/local-k8s-quickstart
+        run: |
+          helm upgrade --install apihub ../qubership-apihub \
+            --namespace qubership-apihub \
+            --create-namespace \
+            --values qubership-apihub/local-k8s-values.yaml \
+            --values qubership-apihub/local-secrets.yaml \
+            --set-string qubershipApihubBackend.image.tag=${{ inputs.apihub-backend-image-tag }} \
+            --set-string qubershipApihubBuildTaskConsumer.image.tag=${{ inputs.apihub-build-task-consumer-image-tag }} \
+            --set-string qubershipApihubUi.image.tag=${{ inputs.apihub-ui-image-tag }} \
+            --set-string qubershipApiLinterService.image.tag=${{ inputs.apihub-api-linter-service-image-tag }} \
+            --set-string qubershipApihubAgentsBackend.image.tag=${{ inputs.apihub-agents-backend-image-tag }} \
+            --wait \
+            --timeout 10m
+
+      - name: Patch APIHUB hosts
+        working-directory: helm-repo/helm-templates/local-k8s-quickstart/scripts
+        run: ./6-patch-apihub-hosts.sh
+
+      - name: Wait for APIHUB rollout
+        run: |
+          kubectl rollout status deployment --all \
+            --namespace qubership-apihub \
+            --timeout=5m
+
+      - name: Forward APIHUB port
+        run: |
+          kubectl port-forward \
+            --namespace qubership-apihub \
+            service/qubership-apihub-ui 8081:8080 \
+            > ./port-forward.log 2>&1 &
+
+      - name: Wait for APIHUB startup
+        run: |
+          echo "Waiting for http://localhost:8081/login to return 200..."
+          end_time=$((SECONDS + 300))
+          while [ $SECONDS -lt $end_time ]; do
+            status_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/login)
+            if [ "$status_code" -eq 200 ]; then
+              echo "Received HTTP 200!"
+              exit 0
+            fi
+            echo "Received HTTP $status_code. Retrying in 5 seconds..."
+            sleep 5
+          done
+          echo "Timeout reached. Did not receive HTTP 200 within 5 minutes."
+          exit 1
+
+      - name: Install Newman
+        if: ${{ inputs.postman-collections-run }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm install -g newman newman-reporter-htmlextra
+
+      - name: Calculate Newman tests branch
+        id: calculate-postman-branch
+        if: ${{ inputs.postman-collections-run }}
+        run: |
+          BRANCH="${{ inputs.postman-repository-branch }}"
+          if [ -n "$BRANCH" ]; then
+            if git ls-remote --heads ${{ inputs.postman-repository-url }} refs/heads/$BRANCH | grep -q $BRANCH; then
+              echo "Branch $BRANCH exists in postman tests repository"
+            else
+              echo "Branch $BRANCH does not exist in postman tests repository, using develop instead"
+              BRANCH="develop"
+            fi
+          else
+            BRANCH="develop"
+            echo "No branch specified, using develop as default"
+          fi
+          echo "Using postman tests repository branch: $BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Clone apihub-postman-collections repository
+        if: ${{ inputs.postman-collections-run }}
+        run: |
+          git clone --branch ${{ steps.calculate-postman-branch.outputs.branch }} --single-branch \
+            ${{ inputs.postman-repository-url }} postman-repo
+
+      - name: Prepare env file for Newman
+        if: ${{ inputs.postman-collections-run }}
+        working-directory: postman-repo
+        env:
+          JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
+          APIHUB_ADMIN_EMAIL: ${{ secrets.APIHUB_ADMIN_EMAIL }}
+          APIHUB_ADMIN_PASSWORD: ${{ secrets.APIHUB_ADMIN_PASSWORD }}
+          APIHUB_ACCESS_TOKEN: ${{ secrets.APIHUB_ACCESS_TOKEN }}
+        run: |
+          envsubst < ./environment/local.postman_environment.json > ./ci.postman_environment.json
+
+      - name: Run Postman Collections with Newman
+        if: ${{ inputs.postman-collections-run }}
+        working-directory: postman-repo
+        run: |
+          IFS=',' read -ra COLLECTIONS <<< "${{ inputs.postman-collections-list }}"
+          for collection in "${COLLECTIONS[@]}"; do
+            sanitized_collection_name=$(echo "$collection" | tr -d './')
+            echo "Running collection: $collection"
+            newman run "$collection" -e ./ci.postman_environment.json -x \
+              --reporters cli,htmlextra \
+              --reporter-htmlextra-export "./reports/${sanitized_collection_name}_results.html"
+          done
+
+      - name: Upload Newman reports as artifacts
+        if: ${{ inputs.postman-collections-run }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: newman-reports
+          path: ${{ github.workspace }}/postman-repo/reports/*.html
+          retention-days: 7
+
+      - name: Run Newman tests results check
+        id: check_newman_tests
+        if: ${{ inputs.postman-collections-run }}
+        continue-on-error: true
+        run: |
+          TOTAL_FAILED=0
+          for file in ${{ github.workspace }}/postman-repo/reports/*.html; do
+            FAILED_TESTS=$(grep -A1 '<h6 class="text-uppercase">Total Failed Tests</h6>' "$file" \
+              | grep -oP '(?<=<h1 class="display-1">)[0-9]+(?=</h1>)')
+            TOTAL_FAILED=$((TOTAL_FAILED + FAILED_TESTS))
+          done
+          if [ "$TOTAL_FAILED" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Calculate Playwright tests branch
+        id: calculate-playwright-branch
+        if: ${{ inputs.playwright-tests-run }}
+        run: |
+          BRANCH="${{ inputs.playwright-repository-branch }}"
+          if [ -n "$BRANCH" ]; then
+            if git ls-remote --heads ${{ inputs.playwright-repository-url }} refs/heads/$BRANCH | grep -q $BRANCH; then
+              echo "Branch $BRANCH exists in playwright tests repository"
+            else
+              echo "Branch $BRANCH does not exist in playwright tests repository, using develop instead"
+              BRANCH="develop"
+            fi
+          else
+            BRANCH="develop"
+            echo "No branch specified, using develop as default"
+          fi
+          echo "Using playwright tests repository branch: $BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Clone Playwright tests repository
+        if: ${{ inputs.playwright-tests-run }}
+        run: |
+          git clone --branch ${{ steps.calculate-playwright-branch.outputs.branch }} --single-branch \
+            ${{ inputs.playwright-repository-url }} playwright-repo
+
+      - name: Install Playwright
+        if: ${{ inputs.playwright-tests-run }}
+        working-directory: playwright-repo
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        id: run_playwright_tests
+        if: ${{ inputs.playwright-tests-run }}
+        continue-on-error: true
+        working-directory: playwright-repo
+        env:
+          BASE_URL: "http://localhost:8081"
+          TEST_USER_PASSWORD: ${{ secrets.APIHUB_ADMIN_PASSWORD }}
+          PLAYGROUND_BACKEND_HOST: "http://host.docker.internal:8081"
+          CLEAR_TD: "skip"
+        run: |
+          npx playwright test ${{ inputs.playwright-test-args }}
+
+      - name: Upload Playwright reports as artifacts
+        if: ${{ inputs.playwright-tests-run }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-reports
+          path: ${{ github.workspace }}/playwright-repo/reports
+          retention-days: 7
+
+      - name: Collect Kubernetes logs
+        if: ${{ always() }}
+        run: |
+          kubectl get all --all-namespaces > ./kubernetes-resources.log 2>&1 || true
+          kubectl get events --all-namespaces \
+            --sort-by='.metadata.creationTimestamp' > ./kubernetes-events.log 2>&1 || true
+          for namespace in postgres-db qubership-apihub ingress-nginx; do
+            kubectl get pods --namespace "$namespace" -o name 2>/dev/null | while read -r pod; do
+              log_name=$(echo "${namespace}-${pod#pod/}" | tr '/' '-')
+              kubectl logs --namespace "$namespace" "$pod" \
+                --all-containers --prefix > "./${log_name}.log" 2>&1 || true
+              kubectl describe --namespace "$namespace" "$pod" \
+                > "./${log_name}-describe.log" 2>&1 || true
+            done
+          done
+
+      - name: Upload Kubernetes logs as artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: kubernetes-logs
+          path: ${{ github.workspace }}/*.log
+          retention-days: 7
+
+      - name: Show test run config
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## Test run configuration"
+            echo "| Parameter | Value |"
+            echo "|---|---|"
+            echo "| Runtime | \`Kind / Kubernetes\` |"
+            echo "| **Execute BE tests** | **\`${{ inputs.postman-collections-run }}\`** |"
+            echo "| Postman branch | \`${{ steps.calculate-postman-branch.outputs.branch || 'branch was not calculated' }}\` |"
+            echo -n "| Postman collections | "
+            IFS=',' read -ra COLLECTIONS <<< "${{ inputs.postman-collections-list }}"
+            for i in "${!COLLECTIONS[@]}"; do
+              if [ "$i" -gt 0 ]; then
+                echo -n "<br>"
+              fi
+              echo -n "\`${COLLECTIONS[$i]}\`"
+            done
+            echo " |"
+            echo "| **Execute UI tests** | **\`${{ inputs.playwright-tests-run }}\`** |"
+            echo "| Playwright branch | \`${{ steps.calculate-playwright-branch.outputs.branch || 'branch was not calculated' }}\` |"
+            echo "| Playwright arguments | \`${{ inputs.playwright-test-args }}\` |"
+            echo "| Backend image tag | \`${{ inputs.apihub-backend-image-tag }}\` |"
+            echo "| Build Task Consumer image tag | \`${{ inputs.apihub-build-task-consumer-image-tag }}\` |"
+            echo "| UI image tag | \`${{ inputs.apihub-ui-image-tag }}\` |"
+            echo "| API Linter Service image tag | \`${{ inputs.apihub-api-linter-service-image-tag }}\` |"
+            echo "| Agents Backend image tag | \`${{ inputs.apihub-agents-backend-image-tag }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail job if there are failed tests
+        if: ${{ always() }}
+        run: |
+          if [ "${{ steps.check_newman_tests.outcome }}" == "failure" ]; then
+            echo "Newman tests failed"
+          fi
+          if [ "${{ steps.run_playwright_tests.outcome }}" == "failure" ]; then
+            echo "Playwright tests failed"
+          fi
+          if [ "${{ steps.check_newman_tests.outcome }}" == "failure" ] \
+            || [ "${{ steps.run_playwright_tests.outcome }}" == "failure" ]; then
+            exit 1
+          fi

--- a/.github/workflows/run-e2e-tests-kind.yaml
+++ b/.github/workflows/run-e2e-tests-kind.yaml
@@ -237,11 +237,12 @@ jobs:
         run: |
           printf '%s' "$APIHUB_ACCESS_TOKEN" > "$RUNNER_TEMP/apihub-agent-access-token"
           helm upgrade --install qubership-apihub-agent ./helm-templates/qubership-apihub-agent \
-            --namespace qubership-apihub-agent \
-            --create-namespace \
+            --namespace qubership-apihub \
             --values ./helm-templates/qubership-apihub-agent/local-k8s-values.yaml \
             --set-string qubershipApihubAgent.version="$APIHUB_AGENT_IMAGE_TAG" \
             --set-string qubershipApihubAgent.image.tag="$APIHUB_AGENT_IMAGE_TAG" \
+            --set-string \
+            qubershipApihubAgent.env.technicalParameters.agentHost=qubership-apihub-agent.qubership-apihub.svc.cluster.local \
             --set-file \
             qubershipApihubAgent.env.technicalParameters.apihub.accessToken="$RUNNER_TEMP/apihub-agent-access-token" \
             --wait \
@@ -253,7 +254,7 @@ jobs:
           APIHUB_ACCESS_TOKEN: ${{ secrets.APIHUB_ACCESS_TOKEN }}
         run: |
           if kubectl get secret qubership-apihub-agent-config-secret \
-            --namespace qubership-apihub-agent \
+            --namespace qubership-apihub \
             --output=jsonpath='{.data.config\.yaml}' \
             | base64 --decode \
             | grep --fixed-strings --quiet -- "$APIHUB_ACCESS_TOKEN"; then
@@ -403,7 +404,7 @@ jobs:
           kubectl get all --all-namespaces > ./kubernetes-resources.log 2>&1 || true
           kubectl get events --all-namespaces \
             --sort-by='.metadata.creationTimestamp' > ./kubernetes-events.log 2>&1 || true
-          for namespace in postgres-db qubership-apihub qubership-apihub-agent ingress-nginx; do
+          for namespace in postgres-db qubership-apihub ingress-nginx; do
             kubectl get pods --namespace "$namespace" -o name 2>/dev/null | while read -r pod; do
               log_name=$(echo "${namespace}-${pod#pod/}" | tr '/' '-')
               kubectl logs --namespace "$namespace" "$pod" \

--- a/.github/workflows/run-e2e-tests-kind.yaml
+++ b/.github/workflows/run-e2e-tests-kind.yaml
@@ -193,6 +193,35 @@ jobs:
               --timeout=5m
           done
 
+      - name: Forward APIHUB port
+        run: |
+          kubectl port-forward \
+            --namespace qubership-apihub \
+            service/qubership-apihub-ui 8081:8080 \
+            > ./port-forward.log 2>&1 &
+
+      - name: Wait for APIHUB startup
+        env:
+          APIHUB_ACCESS_TOKEN: ${{ secrets.APIHUB_ACCESS_TOKEN }}
+        run: |
+          echo "Waiting for APIHUB UI and API key authentication..."
+          end_time=$((SECONDS + 300))
+          while [ $SECONDS -lt $end_time ]; do
+            login_status=$(curl -s -o /dev/null -w "%{http_code}" \
+              http://localhost:8081/login || true)
+            api_key_status=$(curl -s -o /dev/null -w "%{http_code}" \
+              --header "api-key: $APIHUB_ACCESS_TOKEN" \
+              http://localhost:8081/api/v1/system/info || true)
+            if [ "$login_status" = "200" ] && [ "$api_key_status" = "200" ]; then
+              echo "APIHUB UI is ready and the API key is accepted."
+              exit 0
+            fi
+            echo "Login status: $login_status; API key status: $api_key_status. Retrying in 5 seconds..."
+            sleep 5
+          done
+          echo "Timeout reached. APIHUB was not ready within 5 minutes."
+          exit 1
+
       - name: Deploy Qubership APIHUB Agent
         if: ${{ inputs.apihub-agent-run }}
         working-directory: apihub-agent-repo
@@ -211,29 +240,6 @@ jobs:
             qubershipApihubAgent.env.technicalParameters.apihub.accessToken="$RUNNER_TEMP/apihub-agent-access-token" \
             --wait \
             --timeout 5m
-
-      - name: Forward APIHUB port
-        run: |
-          kubectl port-forward \
-            --namespace qubership-apihub \
-            service/qubership-apihub-ui 8081:8080 \
-            > ./port-forward.log 2>&1 &
-
-      - name: Wait for APIHUB startup
-        run: |
-          echo "Waiting for http://localhost:8081/login to return 200..."
-          end_time=$((SECONDS + 300))
-          while [ $SECONDS -lt $end_time ]; do
-            status_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/login)
-            if [ "$status_code" -eq 200 ]; then
-              echo "Received HTTP 200!"
-              exit 0
-            fi
-            echo "Received HTTP $status_code. Retrying in 5 seconds..."
-            sleep 5
-          done
-          echo "Timeout reached. Did not receive HTTP 200 within 5 minutes."
-          exit 1
 
       - name: Install Newman
         if: ${{ inputs.postman-collections-run }}

--- a/.github/workflows/run-e2e-tests-kind.yaml
+++ b/.github/workflows/run-e2e-tests-kind.yaml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Patch APIHUB hosts
         working-directory: helm-repo/helm-templates/local-k8s-quickstart/scripts
-        run: ./6-patch-apihub-hosts.sh
+        run: sh ./6-patch-apihub-hosts.sh
 
       - name: Wait for APIHUB rollout
         run: |

--- a/.github/workflows/run-e2e-tests-kind.yaml
+++ b/.github/workflows/run-e2e-tests-kind.yaml
@@ -61,6 +61,18 @@ on:
         description: "Agents Backend image tag to be executed"
         type: string
         default: "dev"
+      apihub-agent-run:
+        description: "Flag for deploying Qubership APIHUB Agent"
+        type: boolean
+        default: true
+      apihub-agent-helm-repository-branch:
+        description: "Qubership APIHUB Agent branch containing Helm templates"
+        type: string
+        default: "develop"
+      apihub-agent-image-tag:
+        description: "Qubership APIHUB Agent image tag to be executed"
+        type: string
+        default: "dev"
     secrets:
       JWT_PRIVATE_KEY:
         required: true
@@ -79,6 +91,14 @@ jobs:
         run: |
           git clone --branch ${{ inputs.helm-repository-branch }} --single-branch \
             ${{ inputs.helm-repository-url }} helm-repo
+
+      - name: Clone Qubership APIHUB Agent Helm repository
+        if: ${{ inputs.apihub-agent-run }}
+        env:
+          APIHUB_AGENT_HELM_BRANCH: ${{ inputs.apihub-agent-helm-repository-branch }}
+        run: |
+          git clone --branch "$APIHUB_AGENT_HELM_BRANCH" --single-branch \
+            https://github.com/Netcracker/qubership-apihub-agent apihub-agent-repo
 
       - name: Install envsubst
         run: |
@@ -168,6 +188,25 @@ jobs:
           kubectl rollout status deployment --all \
             --namespace qubership-apihub \
             --timeout=5m
+
+      - name: Deploy Qubership APIHUB Agent
+        if: ${{ inputs.apihub-agent-run }}
+        working-directory: apihub-agent-repo
+        env:
+          APIHUB_ACCESS_TOKEN: ${{ secrets.APIHUB_ACCESS_TOKEN }}
+          APIHUB_AGENT_IMAGE_TAG: ${{ inputs.apihub-agent-image-tag }}
+        run: |
+          printf '%s' "$APIHUB_ACCESS_TOKEN" > "$RUNNER_TEMP/apihub-agent-access-token"
+          helm upgrade --install qubership-apihub-agent ./helm-templates/qubership-apihub-agent \
+            --namespace qubership-apihub-agent \
+            --create-namespace \
+            --values ./helm-templates/qubership-apihub-agent/local-k8s-values.yaml \
+            --set-string qubershipApihubAgent.version="$APIHUB_AGENT_IMAGE_TAG" \
+            --set-string qubershipApihubAgent.image.tag="$APIHUB_AGENT_IMAGE_TAG" \
+            --set-file \
+            qubershipApihubAgent.env.technicalParameters.apihub.accessToken="$RUNNER_TEMP/apihub-agent-access-token" \
+            --wait \
+            --timeout 5m
 
       - name: Forward APIHUB port
         run: |
@@ -332,7 +371,7 @@ jobs:
           kubectl get all --all-namespaces > ./kubernetes-resources.log 2>&1 || true
           kubectl get events --all-namespaces \
             --sort-by='.metadata.creationTimestamp' > ./kubernetes-events.log 2>&1 || true
-          for namespace in postgres-db qubership-apihub ingress-nginx; do
+          for namespace in postgres-db qubership-apihub qubership-apihub-agent ingress-nginx; do
             kubectl get pods --namespace "$namespace" -o name 2>/dev/null | while read -r pod; do
               log_name=$(echo "${namespace}-${pod#pod/}" | tr '/' '-')
               kubectl logs --namespace "$namespace" "$pod" \
@@ -377,6 +416,9 @@ jobs:
             echo "| UI image tag | \`${{ inputs.apihub-ui-image-tag }}\` |"
             echo "| API Linter Service image tag | \`${{ inputs.apihub-api-linter-service-image-tag }}\` |"
             echo "| Agents Backend image tag | \`${{ inputs.apihub-agents-backend-image-tag }}\` |"
+            echo "| **Deploy APIHUB Agent** | **\`${{ inputs.apihub-agent-run }}\`** |"
+            echo "| APIHUB Agent Helm branch | \`${{ inputs.apihub-agent-helm-repository-branch }}\` |"
+            echo "| APIHUB Agent image tag | \`${{ inputs.apihub-agent-image-tag }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail job if there are failed tests

--- a/.github/workflows/run-e2e-tests-kind.yaml
+++ b/.github/workflows/run-e2e-tests-kind.yaml
@@ -185,9 +185,13 @@ jobs:
 
       - name: Wait for APIHUB rollout
         run: |
-          kubectl rollout status deployment --all \
+          for deployment in $(kubectl get deployments \
             --namespace qubership-apihub \
-            --timeout=5m
+            --output=name); do
+            kubectl rollout status "$deployment" \
+              --namespace qubership-apihub \
+              --timeout=5m
+          done
 
       - name: Deploy Qubership APIHUB Agent
         if: ${{ inputs.apihub-agent-run }}


### PR DESCRIPTION
## Summary
- add a reusable E2E workflow that deploys APIHUB and PostgreSQL to a Kind cluster with Helm
- preserve Newman and Playwright execution, reports, test result aggregation, and run summaries
- collect Kubernetes pod logs, resource state, events, and pod descriptions for diagnostics

## Test plan
- [x] Validate workflow syntax with actionlint
- [x] Validate YAML syntax and IDE diagnostics
- [x] Invoke the reusable workflow from an application repository and verify the Kind deployment
- [x] Verify Newman and Playwright suites against the forwarded APIHUB endpoint