### PR TITLE
fix: add newman and job timeouts to E2E workflows

### DIFF
--- a/.github/workflows/run-e2e-tests-kind.yaml
+++ b/.github/workflows/run-e2e-tests-kind.yaml
@@ -26,6 +26,14 @@ on:
         description: "Collections to execute"
         type: string
         default: "./e2e/1_1_Smoke_Portal.postman_collection.json"
+      newman-timeout-request:
+        description: "Newman timeout for a single request, in milliseconds"
+        type: number
+        default: 60000
+      newman-timeout-collection:
+        description: "Newman timeout for a whole collection run, in milliseconds"
+        type: number
+        default: 1200000
       playwright-tests-run:
         description: "Flag for executing playwright tests"
         type: boolean
@@ -73,6 +81,10 @@ on:
         description: "Qubership APIHUB Agent image tag to be executed"
         type: string
         default: "dev"
+      job-timeout-minutes:
+        description: "Timeout for the whole E2E job, in minutes"
+        type: number
+        default: 120
     secrets:
       JWT_PRIVATE_KEY:
         required: true
@@ -86,6 +98,7 @@ on:
 jobs:
   run_kind_and_run_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.job-timeout-minutes }}
     steps:
       - name: Clone deployment repository
         run: |
@@ -336,6 +349,8 @@ jobs:
             sanitized_collection_name=$(echo "$collection" | tr -d './')
             echo "Running collection: $collection"
             newman run "$collection" -e ./ci.postman_environment.json -x \
+              --timeout ${{ inputs.newman-timeout-collection }} \
+              --timeout-request ${{ inputs.newman-timeout-request }} \
               --reporters cli,htmlextra \
               --reporter-htmlextra-export "./reports/${sanitized_collection_name}_results.html"
           done

--- a/.github/workflows/run-e2e-tests-kind.yaml
+++ b/.github/workflows/run-e2e-tests-kind.yaml
@@ -29,11 +29,11 @@ on:
       newman-timeout-request:
         description: "Newman timeout for a single request, in milliseconds"
         type: number
-        default: 60000
+        default: 120000
       newman-timeout-collection:
         description: "Newman timeout for a whole collection run, in milliseconds"
         type: number
-        default: 1200000
+        default: 1800000
       playwright-tests-run:
         description: "Flag for executing playwright tests"
         type: boolean

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -34,6 +34,14 @@ on:
         description: "Collections to execute"
         type: string
         default: "./e2e/1_1_Smoke_Portal.postman_collection.json"
+      newman-timeout-request:
+        description: "Newman timeout for a single request, in milliseconds"
+        type: number
+        default: 60000
+      newman-timeout-collection:
+        description: "Newman timeout for a whole collection run, in milliseconds"
+        type: number
+        default: 1200000
       playwright-tests-run:
         description: "Flag for executing playwright tests"
         type: boolean
@@ -69,6 +77,10 @@ on:
         description: "Agents Backend image tag to be executed"
         type: string
         default: "dev"
+      job-timeout-minutes:
+        description: "Timeout for the whole E2E job, in minutes"
+        type: number
+        default: 120
     secrets:
       JWT_PRIVATE_KEY:
         required: true
@@ -82,6 +94,7 @@ on:
 jobs:
   run_compose_and_run_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.job-timeout-minutes }}
     steps:
       - name: Clone compose repository
         run: |
@@ -218,7 +231,7 @@ jobs:
           for collection in "${COLLECTIONS[@]}"; do
             sanitized_collection_name=$(echo "$collection" | tr -d './')
             echo "Running collection: $collection"
-            newman run "$collection" -e ./ci.postman_environment.json -x --reporters cli,htmlextra --reporter-htmlextra-export "./reports/${sanitized_collection_name}_results.html"
+            newman run "$collection" -e ./ci.postman_environment.json -x --timeout ${{ inputs.newman-timeout-collection }} --timeout-request ${{ inputs.newman-timeout-request }} --reporters cli,htmlextra --reporter-htmlextra-export "./reports/${sanitized_collection_name}_results.html"
           done
 
       - name: Upload Newman reports as artifacts

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -37,11 +37,11 @@ on:
       newman-timeout-request:
         description: "Newman timeout for a single request, in milliseconds"
         type: number
-        default: 60000
+        default: 120000
       newman-timeout-collection:
         description: "Newman timeout for a whole collection run, in milliseconds"
         type: number
-        default: 1200000
+        default: 1800000
       playwright-tests-run:
         description: "Flag for executing playwright tests"
         type: boolean


### PR DESCRIPTION
## Problem

A hung backend can keep the shared E2E workflow running for the full GitHub Actions **6-hour** job default. Nothing in the chain had a timeout:

1. **No newman request timeout.** `newman run` was invoked without `--timeout`, `--timeout-request` or `--timeout-script`. Newman's default request timeout is `0` — wait forever. A single request that never returns blocks the collection indefinitely.
2. **No job-level `timeout-minutes`.** Neither `run_compose_and_run_tests` (`run-e2e-tests.yml`) nor `run_kind_and_run_tests` (`run-e2e-tests-kind.yaml`) set one, so both inherited GitHub's 6-hour default.

The trigger was [Netcracker/qubership-apihub run 31937080227](https://github.com/Netcracker/qubership-apihub/actions/runs/31937080227), which sat on the **"Run Postman Collections with Newman"** step for **3h25m** before a human cancelled it. The underlying cause there was a container that died on startup so build tasks were never processed. **That bug is fixed elsewhere and is not what this PR addresses** — this PR fixes the fact that the workflow had no way to *notice*.

## Fix

Both timeouts, in both workflows, exposed as `workflow_call` inputs with defaults (matching the existing convention in these files) so callers can tune them without editing the shared workflow:

| Input | Default | Maps to |
|---|---|---|
| `newman-timeout-request` | `120000` (2 min) | `newman --timeout-request` |
| `newman-timeout-collection` | `1800000` (30 min) | `newman --timeout` |
| `job-timeout-minutes` | `120` | `jobs.<id>.timeout-minutes` |

## How the values were derived

Measured, not reasoned. Sample: **18 successful runs** of *"Manual Run E2E Tests Workflow"* in `Netcracker/qubership-apihub`, **2026-07-27 → 2026-08-16** — **14 nightly `schedule` + 4 `workflow_dispatch`**.

Sampling notes, stated plainly:

- Only successful runs were used. Failed and cancelled runs would bias durations in both directions.
- The sample is schedule-weighted but not schedule-only: the four `workflow_dispatch` runs retained (`30370380146`, `30820522993`, `30826073499`, `31677323487`) all ran the full six-collection set and sit inside the same duration band as the nightlies, so the dispatch path is represented rather than assumed.
- A further **four** otherwise-successful `workflow_dispatch` runs were **excluded**: they ran Playwright only, with an empty collection list and therefore a zero-length newman step, so they carry no signal for the newman timeouts. A dispatch run using a different image tag or a narrower collection subset than the nightly set is therefore still not represented in these figures.
- One further successful run (`31136862176`, 2026-08-07) had job-level timings but its **log had already aged out**, so per-collection data could not be extracted from it. It is excluded from the collection table.

Method: `gh api .../actions/jobs/<id>` for step boundaries, and the run log parsed for newman's own CLI summary block (`total run duration`, `average response time [min/max/s.d.]`, request counts) keyed off the `Running collection: <name>` marker printed before each. That yields **108 collection runs** covering roughly **31,800 individual HTTP requests**.

### Per-collection duration (n = 18 runs each, seconds)

| Collection | median | max | requests |
|---|---:|---:|---:|
| `1_1_Smoke_Portal` | 371.5 | 424.3 | 275 |
| `1_3_Linter_Portal` | 11.0 | 24.0 | 25 |
| `2_1_Negative_Portal` | 54.7 | 55.0 | 196 |
| **`3_1_Stories_Bugs`** | **911.2** | **911.9** | 472 |
| `3_2_Stories_Bugs` | 30.8 | 30.8 | 19 |
| `4_Access_control` | 415.8 | 417.8 | 781 |

Across all 108 collection runs: median **212.7 s**, max **911.9 s** (15m12s).

### Step and job duration (n = 18)

| Metric | median | max |
|---|---:|---:|
| Newman step | 30.1 min | 31.0 min |
| Whole job | 61.7 min | 63.0 min |

### Single-response times

Of ~31,800 requests, **only four exceeded 1 second**. The slowest routine response in the entire sample was **976 ms**. The four outliers:

| Duration | Where |
|---:|---|
| 52.4 s | `1_1_Smoke_Portal` — `POST /api/internal/users`, first request of the run |
| 26.2 s | same request, different run |
| 19.3 s | same request, different run |
| 10.0 s | `1_3_Linter_Portal`, a `201 Created` |

**On percentiles:** n = 18 runs supports median and max honestly, and p90 at the collection level (n = 108). It does **not** support a meaningful p95/p99 on job duration, and no such figure is claimed here. The response-time figures are min/max/mean/s.d. as newman reports them — newman does not emit true per-request percentiles, so none are quoted.

## The three values

### `newman-timeout-request`: 60000 → **120000** — changed, the old value was wrong

This one was **badly calibrated**. The observed maximum single response is **52,400 ms** — a cold-start `POST /api/internal/users` ("Create user (if no exists)") against a backend that had only just come up. That same request is **~25 ms** on a warm stack; it blew out on three separate runs in the 2026-08-13…14 window. `60000` left only **1.15x** headroom over a response that was legitimate and *completed*, so a marginally slower runner would have converted a green run red.

`120000` is **2.29x the observed maximum** and ~123x the worst routine response (976 ms). Still fails a genuinely wedged request in two minutes rather than never.

### `newman-timeout-collection`: 1200000 → **1800000** — changed, the old value was thin

`3_1_Stories_Bugs` runs **911.9 s (15m12s)** at its observed maximum, so `1200000` (20 min) was only **1.32x** that. Its variance across healthy runs is very tight (905–912 s), which superficially argues the 32% margin is fine. It isn't, for two reasons:

1. Its duration is dominated by **polling `Get publish status`** while APIHUB processes builds asynchronously — precisely the kind of wait that stretches under runner and backend load, unlike CPU-bound work.
2. Low variance in a healthy sample does not bound the tail. This same dataset contains a request that went from 25 ms to 52.4 s — a **2000x excursion** — which is direct evidence that this environment produces large latency spikes that eighteen healthy runs do not predict.

`1800000` is **1.97x the observed maximum** and still caps a hung collection at 30 minutes: half the job budget, and bounded where newman's default of `0` was unbounded.

### `job-timeout-minutes`: **120 — unchanged, the data says it is already right**

Slowest successful job in the sample is **63.0 min**, median 61.7 min. `120` is **1.90x** the observed maximum while still being a 3x improvement on GitHub's 6-hour default. No change made. Adjusting it would be motion without justification.

### The trade-off

Headroom is bought against two opposing failure modes: too tight and healthy runs flake on a noisy shared runner; too loose and the timeout stops being a fail-fast mechanism. The rule applied here is **~2x the observed maximum at every layer** (2.29x, 1.97x, 1.90x) — enough to absorb the excursions actually present in the data, small enough that a stall is caught in minutes rather than hours. The three defaults are layered: the request timeout is the fast path, the collection timeout catches a collection that limps rather than hangs, and `timeout-minutes` is the backstop for everything outside newman (podman/Kind bring-up, image pulls, Playwright).

### Legitimately slow operations that must not break

Explicitly checked, since a request timeout that severs a legitimate long-poll would create exactly the flakiness this PR is meant to avoid:

- **Async APIHUB builds.** `3_1_Stories_Bugs` polls `Get publish status` repeatedly while builds complete. Each poll is a *fast* request (that collection's mean response time is 8 ms); the waiting happens *between* requests. So polling is bounded by `--timeout`, not `--timeout-request`, and the 30-minute collection budget covers it at ~2x.
- **Cold start.** The first request of the run is the genuine risk to `--timeout-request`, and is the sole reason that value was raised. At 120 s it has 2.29x margin over the worst instance observed.
- **`1_3_Linter_Portal`**, slow by nature, is in practice the *shortest* collection in the set (median 11 s, max 24 s). Its one 10 s response sits at 8% of the new request timeout. Not at risk.
- `4_Access_control` has the highest mean response time in the set (65 ms) across the most requests (781). Its worst single response is 976 ms — 0.8% of the new request timeout.

## Scope

**In scope — both workflows fixed together.** `run-e2e-tests-kind.yaml` had the *identical* gap (same newman invocation, same missing `timeout-minutes`), and it is a near-copy of `run-e2e-tests.yml`. Fixing only one would leave the same 6-hour failure mode live on the Kind path and guarantee the two files drift, so both are fixed here with identical input names and defaults.

**Deliberately out of scope:**

- **`-x` is kept.** `--suppress-exit-code` is intentional: the later *"Run Newman tests results check"* step parses the HTML reports to decide pass/fail. Not touched.
- **Newman *errors* are not currently surfaced correctly.** Worth flagging, but not fixed here. With `-x`, newman exits `0` even when the *run itself* fails (connection refused, or now a `--timeout` / `--timeout-request` expiry) rather than a test merely asserting false. The results-check step only sums `Total Failed Tests` from the HTML reports that exist on disk — so a collection that aborts early and writes a partial or no report can be scored as a pass. The new timeouts make a stall *fast* but do not by themselves make it *loud*. The proper fix is to capture newman's real exit code per collection (e.g. run without `-x` into a recorded status, or add a reporter-independent failure marker) and fail the job on it. Left for a separate change to keep this PR surgical.
- **`--timeout-script` not added.** It also defaults to `0`, but the collections live in another repo and some use script-side polling loops; picking a script timeout blind risks introducing flakiness for no benefit here. The per-collection `--timeout` already bounds a runaway script.
- **Playwright step.** Checked, as requested. It is left alone: Playwright applies its own per-test timeout (30 s by default) from the test project's config, so a single hung action cannot stall the suite the way an infinite newman request can, and the step already runs under `continue-on-error: true` with the new job-level `timeout-minutes` as its backstop. Adding `--global-timeout` here would override the tests repo's own configuration from the CI side, which is a policy change rather than a bug fix.

## Validation

YAML validated with a real parser (`python -c` + **PyYAML 6.0.3**), not visual inspection — both files parse, and the three input defaults plus `timeout-minutes` were asserted on the parsed tree in both files (`120000` / `1800000` / `120`, all parsed as integers). No behavioural change to any healthy run: every value is a ceiling at ~2x the observed maximum, and no existing line was reformatted.
